### PR TITLE
Handle non standard placement of distortions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # PUNCH_IDL_Tools
-Tools for accessing PUNCH data in IDL and/or GDL.
+Tools for accessing PUNCH data in [IDL](https://www.nv5geospatialsoftware.com/docs/using_idl_home.html) and/or [GDL](https://github.com/gnudatalanguage/gdl).
 
 These tools require the `gen` and `astrom` packages from
-[SolarSoft](https://www.lmsal.com/solarsoft/).
+[SolarSoft](https://www.lmsal.com/solarsoft/), and optionally the
+`vso/ontology` package.
 
 The intent is that they will allow SolarSoft users to ingest and
 interpret any level of PUNCH data from Level 0 to 3. 
@@ -13,16 +14,25 @@ GIT of GDL.
 ## Status
 
 These routines have as yet had limited testing. In particular, as yet
-no images with non-null distortion tables have been available for testing.
+no images with non-null distortion tables have been available for
+testing.
+
+All testing by the Author has been on Linux systems ([OpenSuSE](https://www.opensuse.org/) with IDL
+and [Manjaro](https://manjaro.org/) with GDL)
 
 ## Tools provided.
 
 ### READ_PUNCH:
 
 Reads a PUNCH FITS file into IDL. This should handle the
-Rice-compressed files either with the shared library and
+Rice-compressed files either with the shared library in the appropriate
+subdirectory of `/soft/rsi/ssw/vobs/ontology/binaries/` and
 `fitsio_read_image` or via the [`imcopy`](####imcopy) command, and the
 regular `readfits` procedure.
+
+In general, it is probably better to use the shared library by adding
+the `/use_shared_lib` keyword. However the use of DLL's is not (yet)
+supported by GDL so `imcopy` must be used in that case.
 
 **N.B.** The layout of a Rice-compressed file is assumed to be:
 
@@ -30,7 +40,8 @@ regular `readfits` procedure.
 * The actual primary data compressed into a BINTABLE in the first
 extension.
 * Uncertainty information in the second extension.
-* Distortion lookup tables in the third and fourth extensions.
+* Distortion lookup tables in later extensions (`fits_info` is used to
+  identify them).
 
 
 ### PUNCH_STACK
@@ -42,7 +53,7 @@ returns supporting data (uncertainties and distortions) as available.
 
 In the current SolarSoft astrometry package, the only way to access
 distortion tables is by opening the file with `fits_open`, but this is
-not possible for RIce-compressed files. These routines therefore
+not possible for Rice-compressed files. These routines therefore
 combine the relevant parts of `fits_xy2ad` and `xy2ad`, and
 `fits_ad2xy` and `ad2xy` respectively.
 
@@ -77,7 +88,7 @@ We welcome all contributions. Please open a pull request to contribute.
 
 #### imcopy
 
-is an anciliary program that is part of the cfitsio
+is an ancillary program that is part of the cfitsio
 library. However many Linux distributions do not build it by
 default. It can be simply built by downloading the [cfitsio
 source](https://heasarc.gsfc.nasa.gov/fitsio/) and going to the
@@ -86,4 +97,5 @@ library is installed):
 
     gcc -o imcopy imcopy.c $(pkg-config -libs -cflags cfitsio$)
 
-and copying the executable to somewhere in your path (e.g. `~/bin`).
+and copying the executable to somewhere in your path
+(e.g. `/usr/local/bin` or `~/bin` if you don't have root access).


### PR DESCRIPTION
Some of the synthetic level-0 files have the distortion images as extensions 4 & 5 rather that 3 & 4, so I've added a fits_info call to check where they are.

I've also updated the README to clarify some points.